### PR TITLE
Fix login/password encoding and bookmark logins

### DIFF
--- a/Hotline/Hotline/HotlineProtocol.swift
+++ b/Hotline/Hotline/HotlineProtocol.swift
@@ -474,21 +474,14 @@ struct HotlineTransactionField {
   }
   
   init(type: HotlineTransactionFieldType, string: String, encoding: String.Encoding = .ascii, encrypt: Bool = false) {
-    var stringInput = string
-    
+    var bytes = [UInt8](string.utf8)
     if encrypt {
-      stringInput = String(string.utf8.map { char in
-        Character(UnicodeScalar(0xFF - char))
-      })
+        bytes = string.utf8.map { char in
+            return 0xFF - char
+        }
     }
-    
-    var stringData: Data?
-    stringData = stringInput.data(using: encoding, allowLossyConversion: true)
-    if stringData == nil {
-      stringData = Data()
-    }
-    
-    self.init(type: type, dataSize: UInt16(stringData!.count), data: [UInt8](stringData!))
+
+    self.init(type: type, dataSize: UInt16(bytes.count), data: [UInt8](bytes))
   }
   
   init(type: HotlineTransactionFieldType, string: String, encrypt: Bool) {

--- a/Hotline/macOS/TrackerView.swift
+++ b/Hotline/macOS/TrackerView.swift
@@ -158,7 +158,7 @@ struct TrackerView: View {
         openWindow(id: "server", value: server)
       }
       else if let bookmark = clickedItem.bookmark, bookmark.type == .server {
-        let server = Server(name: bookmark.name, description: nil, address: bookmark.address, port: HotlinePorts.DefaultServerPort)
+        let server = Server(name: bookmark.name, description: nil, address: bookmark.address, port: bookmark.port, login: bookmark.login ?? "", password: bookmark.password ?? "")
         openWindow(id: "server", value: server)
       }
     }


### PR DESCRIPTION
Heya, this is my first time touching a Swift project so I'm not sure if this is a reasonable solution, but this PR fixes two problems for me:

1. logging in with a non-default user/pass from the Connect to Server window
2. logging in with non-default user, or pass from a saved bookmark

For the login/pass string encoding, it seems like `stringInput.data(using: encoding, allowLossyConversion: true)` was producing the wrong bytes in some way I couldn't understand, so switched up to using `[UInt8]` and that seemed to work.

I hope this helps and thanks for your work on this.