### PR TITLE
Add handling for new news post transaction

### DIFF
--- a/Hotline/Hotline/HotlineClient.swift
+++ b/Hotline/Hotline/HotlineClient.swift
@@ -40,6 +40,7 @@ protocol HotlineClientDelegate: AnyObject {
   func hotlineReceivedUserAccess(options: HotlineUserAccessOptions)
   func hotlineUserChanged(user: HotlineUser)
   func hotlineUserDisconnected(userID: UInt16)
+  func hotlineReceivedNewsPost(message: String)
 }
 
 extension HotlineClientDelegate {
@@ -51,6 +52,7 @@ extension HotlineClientDelegate {
   func hotlineReceivedUserAccess(options: HotlineUserAccessOptions) {}
   func hotlineUserChanged(user: HotlineUser) {}
   func hotlineUserDisconnected(userID: UInt16) {}
+  func hotlineReceivedNewsPost(message: String) {}
 }
 
 enum HotlineClientStage {
@@ -342,6 +344,12 @@ class HotlineClient: NetSocketDelegate {
           self.delegate?.hotlineReceivedUserAccess(options: accessOptions)
         }
       }
+    
+    case .newMessage:
+       if let messageField = packet.getField(type: .data),
+          let message = messageField.getString() {
+          self.delegate?.hotlineReceivedNewsPost(message: message)
+       }
       
     default:
       print("HotlineClient: UNKNOWN transaction \(packet.type) with \(packet.fields.count) parameters")

--- a/Hotline/Models/Hotline.swift
+++ b/Hotline/Models/Hotline.swift
@@ -649,6 +649,19 @@ final class Hotline: HotlineClientDelegate, HotlineFileClientDelegate {
   func hotlineReceivedAgreement(text: String) {
     self.chat.append(ChatMessage(text: text, type: .agreement, date: Date()))
   }
+    
+  func hotlineReceivedNewsPost(message: String) {
+    soundEffects.playSoundEffect(.newNews)
+    let messageBoardRegex = /([\s\r\n]*[_\-]+[\s\r\n]+)/
+    let matches = message.matches(of: messageBoardRegex)
+
+    if matches.count == 1 {
+      let range = matches[0].range
+      self.messageBoard.insert(String(message[message.startIndex..<range.lowerBound]), at: 0)
+    } else {
+      self.messageBoard.insert(message, at: 0)
+    }
+  }
   
   func hotlineReceivedServerMessage(message: String) {
 //    print("Hotline: received server message:\n\(message)")

--- a/Hotline/Utility/SoundEffects.swift
+++ b/Hotline/Utility/SoundEffects.swift
@@ -7,6 +7,7 @@ enum SoundEffects: String {
   case transferComplete = "transfer-complete"
   case userLogin = "user-login"
   case userLogout = "user-logout"
+  case newNews = "new-news"
 }
 
 @Observable


### PR DESCRIPTION
This adds handling for the new news post transaction (102) by playing the new-news sound and updating the flat news message board with the new news post.

I copied `messageBoardRegex` from sendGetMessageBoard to help with parsing out the delimiter string, but perhaps it should be moved somewhere re-usable?