### PR TITLE
Add "Show Join/Leave in Chat" option

### DIFF
--- a/Hotline/Models/Hotline.swift
+++ b/Hotline/Models/Hotline.swift
@@ -810,7 +810,10 @@ class Hotline: Equatable, HotlineClientDelegate, HotlineFileClientDelegate {
   func hotlineUserDisconnected(userID: UInt16) {
     if let existingUserIndex = self.users.firstIndex(where: { $0.id == UInt(userID) }) {
       let user = self.users.remove(at: existingUserIndex)
-      self.chat.append(ChatMessage(text: "\(user.name) left", type: .status, date: Date()))
+      
+      if Prefs.shared.showJoinLeaveMessages {
+        self.chat.append(ChatMessage(text: "\(user.name) left", type: .status, date: Date()))
+      }
       
       if Prefs.shared.playSounds && Prefs.shared.playLeaveSound {
         SoundEffectPlayer.shared.playSoundEffect(.userLogout)
@@ -928,7 +931,9 @@ class Hotline: Equatable, HotlineClientDelegate, HotlineFileClientDelegate {
       
       print("Hotline: added user: \(user.name)")
       self.users.append(User(hotlineUser: user))
-      self.chat.append(ChatMessage(text: "\(user.name) joined", type: .status, date: Date()))
+      if Prefs.shared.showJoinLeaveMessages {
+        self.chat.append(ChatMessage(text: "\(user.name) joined", type: .status, date: Date()))
+      }
     }
   }
   

--- a/Hotline/Models/Preferences.swift
+++ b/Hotline/Models/Preferences.swift
@@ -17,6 +17,7 @@ enum PrefsKeys: String {
   case playErrorSound = "play error sound"
   case playChatInvitationSound = "play chat invitation sound"
   case showBannerToolbar = "show banner toolbar"
+  case showJoinLeaveMessages = "show join leave messages"
 }
 
 @Observable
@@ -39,6 +40,7 @@ class Prefs {
       PrefsKeys.playErrorSound.rawValue: true,
       PrefsKeys.playChatInvitationSound.rawValue: true,
       PrefsKeys.showBannerToolbar.rawValue: true,
+      PrefsKeys.showJoinLeaveMessages.rawValue: true,
     ])
     
     self.username = UserDefaults.standard.string(forKey: PrefsKeys.username.rawValue)!
@@ -57,6 +59,7 @@ class Prefs {
     self.playErrorSound = UserDefaults.standard.bool(forKey: PrefsKeys.playErrorSound.rawValue)
     self.playChatInvitationSound = UserDefaults.standard.bool(forKey: PrefsKeys.playChatInvitationSound.rawValue)
     self.showBannerToolbar = UserDefaults.standard.bool(forKey: PrefsKeys.showBannerToolbar.rawValue)
+    self.showJoinLeaveMessages = UserDefaults.standard.bool(forKey: PrefsKeys.showJoinLeaveMessages.rawValue)
   }
   
   public static let shared = Prefs()
@@ -123,5 +126,9 @@ class Prefs {
   
   var showBannerToolbar: Bool {
     didSet { UserDefaults.standard.set(self.showBannerToolbar, forKey: PrefsKeys.showBannerToolbar.rawValue) }
+  }
+  
+  var showJoinLeaveMessages: Bool {
+    didSet { UserDefaults.standard.set(self.showJoinLeaveMessages, forKey: PrefsKeys.showJoinLeaveMessages.rawValue) }
   }
 }

--- a/Hotline/macOS/SettingsView.swift
+++ b/Hotline/macOS/SettingsView.swift
@@ -11,6 +11,7 @@ struct GeneralSettingsView: View {
     
     Form {
       TextField("Your Name", text: $username, prompt: Text("guest"))
+      Toggle("Show Join/Leave in Chat", isOn: $preferences.showJoinLeaveMessages)
       Toggle("Refuse private messages", isOn: $preferences.refusePrivateMessages)
       Toggle("Refuse private chat", isOn: $preferences.refusePrivateChat)
       Toggle("Automatic Response", isOn: $preferences.enableAutomaticMessage)


### PR DESCRIPTION
This small change adds an option to toggle the Join/Leave messages in public chat, similar to the original client option.

<img width="504" alt="Screenshot 2024-05-11 at 7 56 28 PM" src="https://github.com/mierau/hotline/assets/868228/f0097116-c2da-4bff-86b7-5528b4cc391b">

<img width="444" alt="Screenshot 2024-05-11 at 7 57 00 PM" src="https://github.com/mierau/hotline/assets/868228/8642bfce-8e6a-405c-b05e-3e93249e5411">
