### PR TITLE
Add search input to tracker list

### DIFF
--- a/Hotline/Models/Bookmark.swift
+++ b/Hotline/Models/Bookmark.swift
@@ -22,7 +22,6 @@ final class Bookmark {
   @Attribute(.allowsCloudEncryption)
   var password: String?
   
-  @Attribute(.ephemeral)
   var expanded: Bool = false
   
   @Attribute(.ephemeral)

--- a/Hotline/macOS/TrackerView.swift
+++ b/Hotline/macOS/TrackerView.swift
@@ -445,11 +445,19 @@ struct TrackerItemView: View {
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .onAppear {
+      // Fetch servers for trackers that are already expanded on appear
+      if bookmark.type == .tracker && bookmark.expanded && bookmark.servers.isEmpty && !bookmark.loading {
+        Task {
+          await bookmark.fetchServers()
+        }
+      }
+    }
     .onChange(of: bookmark.expanded) {
       guard bookmark.type == .tracker else {
         return
       }
-      
+
       if bookmark.expanded {
         Task {
           await bookmark.fetchServers()


### PR DESCRIPTION
Heya Dustin, been a while, hope all is well in your world! 👋 

I'm sometimes frustrated that I can't find my own server in the tracker list, so I took a stab at adding a search input to the tracker listing to match the functionality in the original client:

<img width="622" height="489" alt="Screenshot 2025-09-19 at 4 47 00 PM" src="https://github.com/user-attachments/assets/11d731e5-17f3-49f7-bc0d-5c2b546b2622" />

In this PR change, the new input looks like:

<img width="1195" height="974" alt="Screenshot 2025-09-19 at 5 22 24 PM" src="https://github.com/user-attachments/assets/6d0cbe56-b8a2-4349-9aac-6181a4deed92" />

<img width="1195" height="974" alt="Screenshot 2025-09-19 at 5 22 28 PM" src="https://github.com/user-attachments/assets/b51d374e-024c-4244-a418-9f033dc4fbc3" />

I also fixed two issues I ran into with the tracker list.

1. The tracker list would collapse when the app loses focus, or when a refresh timer fires.  Fixed in https://github.com/mierau/hotline/commit/af6ea9e7c21883337a360c3d61501469e3091353.
2. The tracker list was expanded by default, but empty.  Fixed in https://github.com/mierau/hotline/commit/43306c40b51507061cde05acb1eb95db611c50e8

