### PR TITLE
Use \r line breaks in private messages for backwards compatibility

### DIFF
--- a/Hotline/Hotline/HotlineClient.swift
+++ b/Hotline/Hotline/HotlineClient.swift
@@ -575,7 +575,7 @@ public actor HotlineClient {
     var transaction = HotlineTransaction(id: self.generateTransactionID(), type: .sendInstantMessage)
     transaction.setFieldUInt16(type: .userID, val: userID)
     transaction.setFieldUInt32(type: .options, val: 1)
-    transaction.setFieldString(type: .data, val: message, encoding: encoding)
+    transaction.setFieldString(type: .data, val: message.convertingLineEndings(to: .cr), encoding: encoding)
 
     try await socket.send(transaction, endian: .big)
   }


### PR DESCRIPTION
This fixes an issue with broken line breaks when sending private messages to an original Macintosh client.

<img width="346" height="203" alt="Screenshot 2026-05-29 at 11 01 41 AM" src="https://github.com/user-attachments/assets/30e48d80-c1a2-4a16-8bdb-68a6f301d9e7" />

Private messages sent from modern client to modern client are unaffected.

